### PR TITLE
編集内容の保存をリロードなしでできるように修正

### DIFF
--- a/app/views/public/deliveries/edit.html.erb
+++ b/app/views/public/deliveries/edit.html.erb
@@ -5,8 +5,8 @@
     </div>
   </div>
   <div class="row">
+    <%= form_with model: @delivery, url: delivery_path, method: :patch do |f| %>
     <table class="table table-borderless">
-      <%= form_with model: @delivery, url: delivery_path(@delivery.id), method: :patch do |f| %>
       <tr>
         <th>郵便番号(ハイフンなし)</th>
         <th><%= f.text_field :post_code, placeholder: "0000000" %></th>
@@ -22,7 +22,7 @@
         <th></th>
         <th><%= f.submit "変更内容を保存" %></th>
       </tr>
-      <% end %>
     </table>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
編集内容の保存ボタンが再読み込みしないと反応しませんでしたが再読み込みしなくても反応するようになりました。
確認お願いします。